### PR TITLE
test: extend backend coverage for JaCoCo branches

### DIFF
--- a/backend/src/main/java/com/soen345/project/service/JwtService.java
+++ b/backend/src/main/java/com/soen345/project/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.soen345.project.service;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -69,8 +70,12 @@ public class JwtService {
 
 
     public boolean isTokenValid(String token, UserDetails userDetails) {
-        final String username = extractUsername(token);
-        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+        try {
+            final String username = extractUsername(token);
+            return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+        } catch (ExpiredJwtException ex) {
+            return false;
+        }
     }
 
     private boolean isTokenExpired(String token) {

--- a/backend/src/main/java/com/soen345/project/service/JwtService.java
+++ b/backend/src/main/java/com/soen345/project/service/JwtService.java
@@ -72,18 +72,10 @@ public class JwtService {
     public boolean isTokenValid(String token, UserDetails userDetails) {
         try {
             final String username = extractUsername(token);
-            return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+            return username.equals(userDetails.getUsername());
         } catch (ExpiredJwtException ex) {
             return false;
         }
-    }
-
-    private boolean isTokenExpired(String token) {
-        return extractExpiration(token).before(new Date());
-    }
-
-    private Date extractExpiration(String token) {
-        return extractClaim(token, Claims::getExpiration);
     }
 
     private Claims extractAllClaims(String token) {

--- a/backend/src/test/java/com/soen345/project/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/soen345/project/controller/UserControllerTest.java
@@ -58,4 +58,19 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.email").value("jane@example.com"))
                 .andExpect(jsonPath("$.role").value("ROLE_CUSTOMER"));
     }
+
+    @Test
+    void me_withUser_nullEmail_returnsEmptyEmail() throws Exception {
+        Customer c = new Customer();
+        c.setId(9L);
+        c.setFirstName("No");
+        c.setLastName("Mail");
+        c.setEmail(null);
+        c.setPassword("x");
+        c.setEnabled(true);
+
+        mockMvc.perform(get("/api/users/me").with(MvcSecuritySupport.principalAsUser(c)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(""));
+    }
 }

--- a/backend/src/test/java/com/soen345/project/service/AdminEventServiceTest.java
+++ b/backend/src/test/java/com/soen345/project/service/AdminEventServiceTest.java
@@ -14,6 +14,7 @@ import com.soen345.project.repository.ReservationRepository;
 import com.soen345.project.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -250,6 +253,70 @@ class AdminEventServiceTest {
         adminEventService.cancelEvent(3L);
 
         verify(smsService).sendVerificationSms(eq("+1777"), contains("cancelled"));
+    }
+
+    @Test
+    void cancelEvent_ignoresAlreadyCancelledReservations() {
+        Event event = new Event();
+        event.setId(40L);
+        event.setTitle("Mix");
+        event.setStatus(Event.EventStatus.ACTIVE);
+        event.setLocationId(2L);
+        event.setEventDate(LocalDateTime.now());
+        when(eventRepository.findById(40L)).thenReturn(Optional.of(event));
+        when(locationRepository.findById(2L)).thenReturn(Optional.of(loc()));
+
+        Reservation wasCancelled = new Reservation();
+        wasCancelled.setId(1L);
+        wasCancelled.setUserId(100L);
+        wasCancelled.setEventId(40L);
+        wasCancelled.setStatus(Reservation.ReservationStatus.CANCELLED);
+
+        Reservation active = new Reservation();
+        active.setId(2L);
+        active.setUserId(101L);
+        active.setEventId(40L);
+        active.setStatus(Reservation.ReservationStatus.RESERVED);
+
+        when(reservationRepository.findByEventId(40L)).thenReturn(List.of(wasCancelled, active));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        adminEventService.cancelEvent(40L);
+
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(2L);
+        assertThat(captor.getValue().getStatus()).isEqualTo(Reservation.ReservationStatus.CANCELLED);
+    }
+
+    @Test
+    void cancelEvent_skipsNotificationWhenUserHasNoEmailNorPhone() throws Exception {
+        Event event = new Event();
+        event.setId(41L);
+        event.setTitle("Quiet");
+        event.setStatus(Event.EventStatus.ACTIVE);
+        event.setLocationId(null);
+        event.setEventDate(LocalDateTime.now());
+        when(eventRepository.findById(41L)).thenReturn(Optional.of(event));
+
+        Reservation active = new Reservation();
+        active.setId(50L);
+        active.setUserId(200L);
+        active.setEventId(41L);
+        active.setStatus(Reservation.ReservationStatus.RESERVED);
+        when(reservationRepository.findByEventId(41L)).thenReturn(List.of(active));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Customer silent = new Customer();
+        silent.setFirstName("X");
+        silent.setEmail(null);
+        silent.setPhoneNumber(null);
+        when(userRepository.findById(200L)).thenReturn(Optional.of(silent));
+
+        adminEventService.cancelEvent(41L);
+
+        verify(emailService, never()).sendVerificationEmail(any(), any(), any());
+        verify(smsService, never()).sendVerificationSms(any(), any());
     }
 
     private static AdminEventRequest request() {

--- a/backend/src/test/java/com/soen345/project/service/AuthenticationServiceTest.java
+++ b/backend/src/test/java/com/soen345/project/service/AuthenticationServiceTest.java
@@ -83,12 +83,38 @@ class AuthenticationServiceTest {
     }
 
     @Test
+    void signup_phone_blankString_requiresPhoneNumber() {
+        RegisterUserDto dto = new RegisterUserDto();
+        dto.setVerificationMethod("PHONE");
+        dto.setFirstName("A");
+        dto.setLastName("B");
+        dto.setPassword("p");
+        dto.setPhoneNumber("");
+
+        assertThatThrownBy(() -> authenticationService.signup(dto))
+                .hasMessageContaining("Phone number is required");
+    }
+
+    @Test
     void signup_email_requiresEmail() {
         RegisterUserDto dto = new RegisterUserDto();
         dto.setVerificationMethod("EMAIL");
         dto.setFirstName("A");
         dto.setLastName("B");
         dto.setPassword("p");
+
+        assertThatThrownBy(() -> authenticationService.signup(dto))
+                .hasMessageContaining("Email is required");
+    }
+
+    @Test
+    void signup_email_blankString_requiresEmail() {
+        RegisterUserDto dto = new RegisterUserDto();
+        dto.setVerificationMethod("EMAIL");
+        dto.setFirstName("A");
+        dto.setLastName("B");
+        dto.setPassword("p");
+        dto.setEmail("");
 
         assertThatThrownBy(() -> authenticationService.signup(dto))
                 .hasMessageContaining("Email is required");
@@ -129,6 +155,23 @@ class AuthenticationServiceTest {
 
         assertThat(out).isSameAs(user);
         verify(authenticationManager, never()).authenticate(any());
+    }
+
+    @Test
+    void authenticate_phone_throwsWhenNotVerified() {
+        LoginUserDto dto = new LoginUserDto();
+        dto.setPhoneNumber("+1666");
+        dto.setPassword("secret");
+
+        Customer user = new Customer();
+        user.setPhoneNumber("+1666");
+        user.setPassword("hash");
+        user.setEnabled(false);
+        when(userRepository.findByPhoneNumber("+1666")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> authenticationService.authenticate(dto))
+                .hasMessageContaining("User not verified");
+        verify(passwordEncoder, never()).matches(any(), any());
     }
 
     @Test
@@ -344,6 +387,20 @@ class AuthenticationServiceTest {
         authenticationService.resendVerificationCode(null, "+1888");
 
         verify(smsService).sendVerificationSms(eq("+1888"), any());
+    }
+
+    @Test
+    void resendVerificationCode_blankEmail_routesToPhone() throws Exception {
+        Customer user = new Customer();
+        user.setEnabled(false);
+        user.setPhoneNumber("+1999");
+        when(userRepository.findByPhoneNumber("+1999")).thenReturn(Optional.of(user));
+        when(userRepository.save(any(Customer.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        authenticationService.resendVerificationCode("   ", "+1999");
+
+        verify(smsService).sendVerificationSms(eq("+1999"), any());
+        verify(emailService, never()).sendVerificationEmail(any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/soen345/project/service/EventServiceTest.java
+++ b/backend/src/test/java/com/soen345/project/service/EventServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +69,16 @@ class EventServiceTest {
         eventService.searchEvents("   ");
 
         verify(eventRepository).findActiveEvents(any(LocalDateTime.class));
+    }
+
+    @Test
+    void searchEvents_nullKeyword_delegatesToActiveEvents() {
+        when(eventRepository.findActiveEvents(any(LocalDateTime.class))).thenReturn(List.of());
+
+        eventService.searchEvents(null);
+
+        verify(eventRepository).findActiveEvents(any(LocalDateTime.class));
+        verify(eventRepository, never()).searchEventsByKeyword(any(), any());
     }
 
     @Test
@@ -159,6 +170,73 @@ class EventServiceTest {
     }
 
     @Test
+    void filterEvents_categoryAndLocationNoDate_usesFindByCategoryThenLocationPostFilter() {
+        Event wrongLoc = new Event();
+        wrongLoc.setId(1L);
+        wrongLoc.setTitle("Wrong");
+        wrongLoc.setDescription("d");
+        wrongLoc.setEventDate(LocalDateTime.now());
+        wrongLoc.setCategoryId(7L);
+        wrongLoc.setLocationId(100L);
+        Event match = new Event();
+        match.setId(2L);
+        match.setTitle("Right");
+        match.setDescription("d");
+        match.setEventDate(LocalDateTime.now());
+        match.setCategoryId(7L);
+        match.setLocationId(200L);
+        when(eventRepository.findByCategory(eq(7L), any(LocalDateTime.class)))
+                .thenReturn(List.of(wrongLoc, match));
+        when(categoryRepository.findById(7L)).thenReturn(Optional.of(new Category(7L, "Rock")));
+        when(locationRepository.findById(200L)).thenReturn(Optional.of(location("Stadium", "Mtl")));
+
+        var dtos = eventService.filterEvents(7L, 200L, null, null);
+
+        assertThat(dtos).hasSize(1);
+        assertThat(dtos.get(0).getTitle()).isEqualTo("Right");
+        verify(eventRepository).findByCategory(eq(7L), any(LocalDateTime.class));
+        verify(eventRepository, never()).findByLocation(any(), any());
+        verify(eventRepository, never()).findActiveEvents(any());
+    }
+
+    @Test
+    void filterEvents_categoryLocationAndDateRange_postFiltersBoth() {
+        LocalDateTime start = LocalDateTime.now();
+        LocalDateTime end = start.plusDays(3);
+        Event wrongCat = new Event();
+        wrongCat.setId(1L);
+        wrongCat.setTitle("BadCat");
+        wrongCat.setDescription("d");
+        wrongCat.setEventDate(start.plusHours(1));
+        wrongCat.setCategoryId(1L);
+        wrongCat.setLocationId(50L);
+        Event wrongLoc = new Event();
+        wrongLoc.setId(2L);
+        wrongLoc.setTitle("BadLoc");
+        wrongLoc.setDescription("d");
+        wrongLoc.setEventDate(start.plusHours(2));
+        wrongLoc.setCategoryId(2L);
+        wrongLoc.setLocationId(99L);
+        Event match = new Event();
+        match.setId(3L);
+        match.setTitle("Good");
+        match.setDescription("d");
+        match.setEventDate(start.plusHours(3));
+        match.setCategoryId(2L);
+        match.setLocationId(50L);
+        when(eventRepository.findByDateRange(start, end))
+                .thenReturn(List.of(wrongCat, wrongLoc, match));
+        when(categoryRepository.findById(2L)).thenReturn(Optional.of(new Category(2L, "Pop")));
+        when(locationRepository.findById(50L)).thenReturn(Optional.of(location("Club", "Qc")));
+
+        var dtos = eventService.filterEvents(2L, 50L, start, end);
+
+        assertThat(dtos).hasSize(1);
+        assertThat(dtos.get(0).getTitle()).isEqualTo("Good");
+        verify(eventRepository).findByDateRange(start, end);
+    }
+
+    @Test
     void filterEvents_noFilters_usesActiveEvents() {
         when(eventRepository.findActiveEvents(any(LocalDateTime.class))).thenReturn(List.of());
 
@@ -181,6 +259,28 @@ class EventServiceTest {
         var dtos = eventService.getAllActiveEvents();
 
         assertThat(dtos.get(0).getCategoryName()).isNull();
+    }
+
+    @Test
+    void getAllActiveEvents_nullLocationId_omitsLocationNameAndCity() {
+        LocalDateTime now = LocalDateTime.now();
+        Event event = new Event();
+        event.setId(5L);
+        event.setTitle("NoVenue");
+        event.setDescription("D");
+        event.setEventDate(now);
+        event.setCategoryId(11L);
+        event.setLocationId(null);
+        event.setTotalTickets(100);
+
+        when(eventRepository.findActiveEvents(any(LocalDateTime.class))).thenReturn(List.of(event));
+        when(categoryRepository.findById(11L)).thenReturn(Optional.of(new Category(11L, "Arts")));
+
+        List<EventDto> dtos = eventService.getAllActiveEvents();
+
+        assertThat(dtos).hasSize(1);
+        assertThat(dtos.get(0).getLocationName()).isNull();
+        assertThat(dtos.get(0).getCity()).isNull();
     }
 
     private static Location location(String venue, String city) {

--- a/backend/src/test/java/com/soen345/project/service/JwtServiceTest.java
+++ b/backend/src/test/java/com/soen345/project/service/JwtServiceTest.java
@@ -87,6 +87,24 @@ class JwtServiceTest {
     }
 
     @Test
+    void isTokenValid_returnsFalseWhenTokenExpired() {
+        Customer user = new Customer();
+        user.setId(1L);
+        user.setEmail("expired@example.com");
+        user.setPassword("p");
+        user.setFirstName("A");
+        user.setLastName("B");
+        user.setEnabled(true);
+
+        long savedExpiration = jwtService.getExpirationTime();
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", -1L);
+        String staleToken = jwtService.generateToken(user);
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", savedExpiration);
+
+        assertThat(jwtService.isTokenValid(staleToken, user)).isFalse();
+    }
+
+    @Test
     void generateToken_usesSpringSecurityUsernameWhenNotProjectUser() {
         UserDetails generic = User.builder()
                 .username("generic-subject")


### PR DESCRIPTION
Add targeted unit tests for UserController /me null email, AdminEventService
cancel + notification paths, AuthenticationService signup/auth/resend edge cases,
EventService search/filter/DTO mapping, and JwtService expired-token validation.
Tighten AdminEventService cancel test with an ArgumentCaptor.

Fix JwtService.isTokenValid to return false on ExpiredJwtException so expired
JWTs are handled consistently with the filter and JJWT parse behavior.