### PR TITLE
Integrate Resend service

### DIFF
--- a/backend/src/main/java/com/soen345/project/config/EmailConfiguration.java
+++ b/backend/src/main/java/com/soen345/project/config/EmailConfiguration.java
@@ -1,6 +1,7 @@
 package com.soen345.project.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -9,6 +10,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 import java.util.Properties;
 
 @Configuration
+@ConditionalOnProperty(name = "resend.enabled", havingValue = "false", matchIfMissing = true)
 public class EmailConfiguration {
     @Value("${spring.mail.username}")
     private String emailUsername;

--- a/backend/src/main/java/com/soen345/project/service/EmailService.java
+++ b/backend/src/main/java/com/soen345/project/service/EmailService.java
@@ -3,23 +3,63 @@ package com.soen345.project.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class EmailService {
-    @Autowired
+
+    @Autowired(required = false)
     private JavaMailSender emailSender;
 
+    @Value("${resend.enabled:false}")
+    private boolean resendEnabled;
+
+    @Value("${resend.api.key:}")
+    private String resendApiKey;
+
+    @Value("${resend.from:onboarding@resend.dev}")
+    private String resendFrom;
+
     public void sendVerificationEmail(String to, String subject, String text) throws MessagingException {
+        if (resendEnabled && resendApiKey != null && !resendApiKey.isBlank()) {
+            sendViaResend(to, subject, text);
+            return;
+        }
+        if (emailSender == null) {
+            throw new MessagingException("Mail not configured: enable Resend (RESEND_ENABLED=true) or Gmail SMTP.");
+        }
         MimeMessage message = emailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
         helper.setTo(to);
         helper.setSubject(subject);
-        helper.setText(text, false); //boolean to true if i want to a nicer html email
+        helper.setText(text, false);
         emailSender.send(message);
     }
 
+    private void sendViaResend(String to, String subject, String body) throws MessagingException {
+        try {
+            RestClient.create()
+                    .post()
+                    .uri("https://api.resend.com/emails")
+                    .header("Authorization", "Bearer " + resendApiKey)
+                    .header("Content-Type", "application/json")
+                    .body(Map.of(
+                            "from", resendFrom,
+                            "to", List.of(to),
+                            "subject", subject,
+                            "text", body))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            throw new MessagingException("Resend send failed: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,12 +11,18 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 security.jwt.secret-key =${JWT_SECRET_KEY}
 security.jwt.expiration-time=3600000
 
+# Gmail SMTP (local / hosts that allow outbound SMTP). Ignored when resend.enabled=true.
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=${SUPPORT_EMAIL}
-spring.mail.password=${APP_PASSWORD}
+spring.mail.username=${SUPPORT_EMAIL:}
+spring.mail.password=${APP_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Resend HTTPS API — works on Railway free tier where SMTP is blocked. https://resend.com
+resend.enabled=${RESEND_ENABLED:false}
+resend.api.key=${RESEND_API_KEY:}
+resend.from=${RESEND_FROM:onboarding@resend.dev}
 
 twilio.account-sid=${TWILIO_ACCOUNT_SID}
 twilio.auth-token=${TWILIO_AUTH_TOKEN}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -18,6 +18,9 @@ twilio.account-sid=test-account-sid
 twilio.auth-token=test-auth-token
 twilio.phone-number=+15555555555
 
+# Use JavaMailSender in tests, not Resend
+resend.enabled=false
+
 # Mail settings (mock for tests)
 spring.mail.host=localhost
 spring.mail.port=3025


### PR DESCRIPTION
This pull request adds support for sending emails via the Resend API as an alternative to SMTP, improving compatibility with platforms where SMTP is blocked (such as Railway). The changes allow switching between Resend and SMTP using configuration properties, and ensure that the application can operate in both environments without code changes.

**Email sending enhancements:**

* Added conditional configuration to `EmailConfiguration` so that it is only active when Resend is disabled (`resend.enabled=false`), allowing seamless switching between SMTP and Resend. [[1]](diffhunk://#diff-56a4fc91d12f6ceda33c9c47d52ef2e3498c424e1bdc7b3da99038efe2f19a33R4) [[2]](diffhunk://#diff-56a4fc91d12f6ceda33c9c47d52ef2e3498c424e1bdc7b3da99038efe2f19a33R13)
* Updated `EmailService` to support sending emails via the Resend API when enabled, with fallback to SMTP if not. The service now reads configuration properties for both methods and throws a clear exception if neither is configured.

**Configuration updates:**

* Updated `application.properties` to include configuration options for enabling Resend, specifying the API key and sender address, and clarified the use of Gmail SMTP settings.
* Updated `application-test.properties` to explicitly disable Resend in tests and ensure that JavaMailSender is used, maintaining predictable test behavior.