### PR TITLE
Enhance integration test coverage for controllers

### DIFF
--- a/backend/src/test/java/com/soen345/project/AdminEventControllerIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/project/AdminEventControllerIntegrationTest.java
@@ -169,6 +169,66 @@ class AdminEventControllerIntegrationTest {
         assertThat(String.valueOf(response.getBody())).contains("Event not found");
     }
 
+    @Test
+    void getEvent_withValidId_returnsOk() {
+        Long eventId = ((EventDto) adminEventController.createEvent(admin, request("Lookup Me", 80)).getBody()).getId();
+
+        ResponseEntity<?> response = adminEventController.getEvent(eventId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(EventDto.class);
+        assertThat(((EventDto) response.getBody()).getTitle()).isEqualTo("Lookup Me");
+    }
+
+    @Test
+    void createEvent_withInvalidCategory_returnsBadRequest() {
+        AdminEventRequest bad = request("Bad Cat", 50);
+        bad.setCategoryId(999_999L);
+
+        ResponseEntity<?> response = adminEventController.createEvent(admin, bad);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Category not found");
+    }
+
+    @Test
+    void updateEvent_withUnknownId_returnsBadRequest() {
+        ResponseEntity<?> response = adminEventController.updateEvent(999_999L, request("Nope", 10));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Event not found");
+    }
+
+    @Test
+    void updateEvent_whenCancelled_returnsBadRequest() {
+        Long eventId = ((EventDto) adminEventController.createEvent(admin, request("Cancel Me", 40)).getBody()).getId();
+        adminEventController.cancelEvent(eventId);
+
+        ResponseEntity<?> response = adminEventController.updateEvent(eventId, request("Try Update", 40));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Event is already cancelled");
+    }
+
+    @Test
+    void cancelEvent_withUnknownId_returnsBadRequest() {
+        ResponseEntity<?> response = adminEventController.cancelEvent(999_999L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Event not found");
+    }
+
+    @Test
+    void cancelEvent_whenAlreadyCancelled_returnsBadRequest() {
+        Long eventId = ((EventDto) adminEventController.createEvent(admin, request("Double Cancel", 30)).getBody()).getId();
+        adminEventController.cancelEvent(eventId);
+
+        ResponseEntity<?> response = adminEventController.cancelEvent(eventId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Event is already cancelled");
+    }
+
     private AdminEventRequest request(String title, int tickets) {
         AdminEventRequest request = new AdminEventRequest();
         request.setTitle(title);

--- a/backend/src/test/java/com/soen345/project/AuthenticationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/project/AuthenticationControllerIntegrationTest.java
@@ -216,6 +216,76 @@ class AuthenticationControllerIntegrationTest {
     }
 
     @Test
+    void test_endpoint_returnsOk() {
+        ResponseEntity<String> response = authenticationController.test();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("Authentication controller is working");
+    }
+
+    @Test
+    void home_returnsWelcomeString() {
+        String body = authenticationController.home();
+
+        assertThat(body).contains("Welcome to Eventigo");
+    }
+
+    @Test
+    void registerAdmin_createsAdministrator() {
+        ResponseEntity<?> response = authenticationController.registerAdmin(
+                signupDto("newadmin@example.com", "5551112222", "EMAIL")
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(userRepository.findByEmail("newadmin@example.com")).isPresent();
+    }
+
+    @Test
+    void registerAdmin_duplicateEmail_returnsBadRequest() {
+        authenticationController.registerAdmin(
+                signupDto("dupadmin@example.com", "5551112222", "EMAIL")
+        );
+
+        ResponseEntity<?> response = authenticationController.registerAdmin(
+                signupDto("dupadmin@example.com", "5551113333", "EMAIL")
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(String.valueOf(response.getBody())).contains("Email already in use");
+    }
+
+    @Test
+    void resendVerification_forUnverifiedUser_returnsOk() {
+        authenticationController.register(
+                signupDto("resend@example.com", "5551112222", "EMAIL")
+        );
+
+        ResponseEntity<?> response = authenticationController.resendVerification("resend@example.com", null);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(String.valueOf(response.getBody())).contains("resent successfully");
+    }
+
+    @Test
+    void checkEmail_returnsFalseWhenMissing() {
+        ResponseEntity<?> response = authenticationController.checkEmail("nobody@example.com");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    void signup_withPhoneVerification_sendsSmsPath() {
+        // DB still requires a non-null email on User; PHONE only selects SMS for verification delivery.
+        ResponseEntity<?> response = authenticationController.register(
+                signupDto("phoneverify@example.com", "+15550001111", "PHONE")
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(userRepository.findByPhoneNumber("+15550001111")).isPresent();
+    }
+
+    @Test
     void resendVerification_forVerifiedUser_returnsBadRequest() {
         authenticationController.register(
                 signupDto("already.verified@example.com", "5551112222", "EMAIL")

--- a/backend/src/test/java/com/soen345/project/EventControllerIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/project/EventControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.soen345.project;
 
+import com.soen345.project.controller.EventController;
 import com.soen345.project.dto.EventDto;
 import com.soen345.project.model.Category;
 import com.soen345.project.model.Event;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -22,6 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ActiveProfiles("test")
 class EventControllerIntegrationTest {
+
+    @Autowired
+    private EventController eventController;
 
     @Autowired
     private EventService eventService;
@@ -123,6 +128,49 @@ class EventControllerIntegrationTest {
 
         assertThat(events).hasSize(1);
         assertThat(events.getFirst().getTitle()).isEqualTo("Jazz Night");
+    }
+
+    @Test
+    void controller_getAllEvents_returnsSameAsService() {
+        ResponseEntity<List<EventDto>> response = eventController.getAllEvents();
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).extracting(EventDto::getTitle)
+                .containsExactlyInAnyOrder("Jazz Night", "Soccer Final");
+    }
+
+    @Test
+    void controller_searchEvents_delegatesToService() {
+        ResponseEntity<List<EventDto>> response = eventController.searchEvents("soccer");
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getTitle()).isEqualTo("Soccer Final");
+    }
+
+    @Test
+    void controller_filterEvents_withCategoryAndLocation() {
+        Long concertId = categoryRepository.findAll().stream()
+                .filter(c -> "Concert".equals(c.getName()))
+                .findFirst().orElseThrow().getId();
+        Long bellId = locationRepository.findAll().stream()
+                .filter(l -> l.getVenueName() != null && l.getVenueName().contains("Bell"))
+                .findFirst().orElseThrow().getId();
+
+        ResponseEntity<List<EventDto>> response = eventController.filterEvents(concertId, bellId, null, null);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getTitle()).isEqualTo("Jazz Night");
+    }
+
+    @Test
+    void controller_filterEvents_withNullParams_returnsAllActiveUpcoming() {
+        ResponseEntity<List<EventDto>> response = eventController.filterEvents(null, null, null, null);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).hasSize(2);
     }
 
     private Event buildEvent(String title,


### PR DESCRIPTION
This pull request adds new integration tests to improve coverage and verify the behavior of the `AdminEventController`, `AuthenticationController`, and `EventController` classes. The new tests check both successful and error scenarios for various endpoints, ensuring that the controllers handle requests and errors as expected.

**AdminEventController tests:**

* Added tests for event retrieval, creation with invalid category, updating and cancelling events with unknown or invalid states, and handling of already-cancelled events.

**AuthenticationController tests:**

* Added tests for the `/test` and `/home` endpoints, admin registration (including duplicate email handling), resending verification for unverified users, checking email existence, and phone verification signup path.

**EventController tests:**

* Added tests to verify that the controller endpoints for retrieving all events, searching, and filtering (with and without parameters) correctly delegate to the service and return the expected results.
* Injected the `EventController` bean and imported necessary dependencies to support the new controller-level tests. [[1]](diffhunk://#diff-e45b02f535ec956380f39b4ea78b4df210ccb015578bf7c8619740b09823033aR3) [[2]](diffhunk://#diff-e45b02f535ec956380f39b4ea78b4df210ccb015578bf7c8619740b09823033aR16) [[3]](diffhunk://#diff-e45b02f535ec956380f39b4ea78b4df210ccb015578bf7c8619740b09823033aR28-R30)